### PR TITLE
 leaderboard is centered correctly

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@ body {
 
 #pointsTable {
   /* width: 20%; */
-  margin: 8rem 0 4rem 35%;
+  margin: 8rem auto;
 }
 
 /* Media Queries */
@@ -30,7 +30,7 @@ body {
   }
 
   #pointsTable {
-    margin: 8rem 70% 4rem 20%;
+    margin: 8rem auto;
   }
 }
 


### PR DESCRIPTION
Issue: 35


#### Short description of what this resolves:

- leaderboard is centered correctly in both mobile and desktop view
- Live demo: https://ashutosh3027.github.io/Leaderboard-Frontend/
- Just edited the margin value previously it is **margin: 8rem 0 4rem 35%** after changes it is **margin: 8rem auto;**

#### Changes proposed in this pull request and/or Screenshots(if applicable):

![Opencode'21 Leaderboard and 5 more pages - Personal - Microsoft​ Edge 05-10-2021 21_50_25](https://user-images.githubusercontent.com/75844019/136063240-e4de4445-2e82-467d-92c9-49b7e9309b58.png)

-
-
-